### PR TITLE
Construct users json directly, not via :includes.

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -9,11 +9,9 @@ class Topic < ActiveRecord::Base
   default_scope includes(:users)
 
   def as_json(options)
-    options.merge!({:include=>[:users]}) unless options.include?(:include)
-    options[:include] = ([options[:include]]) unless options[:include].is_a?(Array)
-    options[:include] << :users unless options[:include].include?(:users)
     json = super(options)
     json['unread_conversations'] = unread_conversations(options[:user])
+    json[:users] = users
     return json
   end
 


### PR DESCRIPTION
https://trello.com/c/2yQ5EEEI/523-don-t-send-too-much-information-in-user-hashes

I don't know why, and I haven't been able to find good
documentation, but apparently using options[:includes] inside
as_json doesn't end up directly hitting the included model's
as_json.  This seems like a pretty terrible bug.
