### PR TITLE
Don't parse folder models.

### DIFF
--- a/app/assets/javascripts/backbone/models/folder.js
+++ b/app/assets/javascripts/backbone/models/folder.js
@@ -39,7 +39,6 @@ Structural.Models.Folder = Backbone.Model.extend({
 
   _inflatedUsersCollection: function(coll) {
     if (coll && !(coll instanceof Backbone.Collection)) {
-      console.log('inflate');
       return new Structural.Collections.FolderParticipants(coll);
     }
     return coll;


### PR DESCRIPTION
https://trello.com/c/9crD33ec/563-folder-inspector-sometimes-shows-empty-names-for-users

N.B. - This is only about half right.  See the comments below and http://watercoolr.io/conversation/backbonecollectionset-peculiarities/268 for clarificaiton.

Backbone.Collection#set appears to call both Folder#parse and
Folder#initialize on the JSON it gets from the server, even
when models corresponding to that JSON already exist.  I'm not
clear on the whys and wherefores of this, but it's true.  The
upshot is that you shouldn't duplicate work in parse and
initialize.  Parse should be used for transforming the JSON from
the server into the JSON for the model, and initialize is for
transforming the JSON into a Backbone object.
