### PR TITLE
Parse participants as collection, not array.

### DIFF
--- a/app/assets/javascripts/backbone/models/conversation.js
+++ b/app/assets/javascripts/backbone/models/conversation.js
@@ -30,9 +30,8 @@ Structural.Models.Conversation = Backbone.Model.extend({
   parse: function (response, options) {
 
     // This gets used later in a template so we need real models from our response.
-    response.participants = _.map(response.participants, function (p) {
-      return new Structural.Models.Participant(p);
-    });
+    response.participants = new Structural.Collections.Participants(response.participants);
+
     return response;
   },
 

--- a/app/assets/javascripts/backbone/templates/conversations/conversation.jst.ejs
+++ b/app/assets/javascripts/backbone/templates/conversations/conversation.jst.ejs
@@ -8,7 +8,7 @@
 <div class='cnv-left'>
   <div class="cnv-title"><%= conversation.escape('title') %></div>
   <div class="cnv-participants">
-    <% conversation.get('participants').forEach(function(participant){%>
+    <% conversation.get('participants').each(function(participant){%>
       <span class="cnv-participant"><%= participant.escape('name') %></span>
     <% }); %>
   </div>


### PR DESCRIPTION
https://trello.com/c/vfJabPkI/592-creating-a-new-conversation-fubars-everything

In the participants view we do `this.collection = conversation.get('participants')` after changing conversations, then expect the result to be a backbone collection, not an array.  The error there was killing the js thread, making the whole app end up wonky. 
