### PR TITLE
Upgrading ruby to 2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby "1.9.3"
+ruby "2.0.0"
 gem 'rails', '>= 3.2.11'
 gem 'pry-rails'
 


### PR DESCRIPTION
This is more administrative stuff than anything else:

rvm get stable
rvm install 2.0
=> installed ruby-2.0.0-p353 for me
rvm use 2.0
bundle install
=> will install everything
pray

I had a bunch of issues with postgres, but I've been having them for a bit. Also, things now generally seem to always require bundle exec to run, so bundle exec rails s for me.
