### PR TITLE
adjust short form compose to be taller

### DIFF
--- a/app/assets/stylesheets/act.css.less
+++ b/app/assets/stylesheets/act.css.less
@@ -120,8 +120,7 @@
   left:0;
   right:0;
   top:4rem;
-  bottom:0;
-  margin-bottom:2.7rem;
+  bottom:3.7rem;
 }
 .act{
   padding:0.125rem;

--- a/app/assets/stylesheets/compose.css.less
+++ b/app/assets/stylesheets/compose.css.less
@@ -279,7 +279,7 @@
   background-color: @bg-1;
   border-top:@border-1;
   padding:0.35rem;
-  min-height: 2.75rem;
+  min-height: 3.7rem;
 }
 
 .act-container.not-participating-in .short-form-compose > *{
@@ -290,11 +290,14 @@
   position: relative;
   margin-right:4rem;
   margin-left:2.5rem;
-  textarea{
-    max-height:10rem;
-    min-height: 2.0rem;
-    height:2.0rem;
-  }
+}
+
+.short-form-textarea{
+  .ui-compose-input();
+  overflow-x:hidden;
+  overflow-y:auto;
+  height:3.0rem;
+  transition:height 0.05s ;
 }
 
 .enable-long-form-group{
@@ -313,7 +316,3 @@
   margin-right:0;
 }
 
-.short-form-textarea{
-  .ui-compose-input();
-  overflow:hidden;
-}


### PR DESCRIPTION
Apparently the scroll bar was also needlessly disabled on short form.  I set overflow back to auto.  

That might solve what people were complaining about by itself.  
