### PR TITLE
Toast false errors

### DIFF
--- a/app/assets/javascripts/backbone/components/toaster.js
+++ b/app/assets/javascripts/backbone/components/toaster.js
@@ -4,7 +4,7 @@ Structural.Components.Toaster = function() {
   var getViewDescription = function(toastDescription) {
     var viewDescription = {};
     viewDescription.state = toastDescription.state;
-    if (toastDescription.errorType === 'backbone:sync') {
+    if (toastDescription.type === 'backbone:sync') {
       viewDescription.promptRefresh = true;
       viewDescription.message =
         "Water Cooler has lost its connection to the server.  Please refresh" +
@@ -18,7 +18,11 @@ Structural.Components.Toaster = function() {
   this.view = new Structural.Views.Toast();
 
   this.toast = function(toastDescription) {
-    var viewDescription = getViewDescription(toastDescription);
-    this.view.show(viewDescription);
+    if (toastDescription.state === 'error') {
+      var viewDescription = getViewDescription(toastDescription);
+      this.view.show(viewDescription);
+    } else if (toastDescription.state === 'success') {
+      this.view.hide();
+    }
   };
 };

--- a/app/assets/javascripts/backbone/monkeypatches/sync_error_toast.js
+++ b/app/assets/javascripts/backbone/monkeypatches/sync_error_toast.js
@@ -19,7 +19,7 @@
           consecutiveErrors >= ConsecutiveErrorsRequiredToToast) {
         Structural.Toaster.toast({
           state: 'error',
-          errorType: 'backbone:sync'
+          type: 'backbone:sync'
         });
       }
 
@@ -31,6 +31,11 @@
     var originalSuccess = options.success;
     options.success = function(model, resp, options) {
       consecutiveErrors = 0;
+
+      Structural.Toaster.toast({
+        state: 'success',
+        type: 'backbone:sync'
+      });
 
       if (originalSuccess) {
         originalSuccess(model, resp, options);


### PR DESCRIPTION
Does three things that should make the toasts less irritating (while still having a first line of defense against sending people's messages to the memory hole).
- Ignore errors that don't come from HTTP responses.  Refreshing the page with a pending request or sleeping the computer or whatever triggers the error callback, but we don't care about those ersatz errors.
- Don't toast unless we get two errors in a row.
- Clear the toast if we start getting successes again.
